### PR TITLE
Add CLI command for free TheSportsDB event lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ probabilities.
 - **Provider Abstraction** – Robust HTTP client with caching, retry logic, and
   an implementation for the [TheSportsDB](https://www.thesportsdb.com/) public
   API.
+- **Free Event Lookups** – Quickly fetch specific fixtures from TheSportsDB's
+  free tier by supplying event identifiers.
 - **Prediction Engine** – Algorithms to estimate spreads, totals, and moneyline
   edges using team performance metrics.
 - **Fantasy Projections** – Flexible scoring rules to produce player fantasy
@@ -48,7 +50,14 @@ probabilities.
    ```bash
    stattrackerpro insights 4328
    stattrackerpro fantasy 34145937
+   stattrackerpro events 2052711 2052712 2052713 2052714
    ```
+
+   The ``events`` command looks up fixtures by ID using the free
+   [TheSportsDB lookup endpoint](https://www.thesportsdb.com/api.php). No
+   payment or subscription is required—just pass the identifiers you care
+   about and the CLI will return the scheduled date along with the home and
+   away teams.
 
 ## Testing
 

--- a/stattrackerpro/cli.py
+++ b/stattrackerpro/cli.py
@@ -25,6 +25,9 @@ def build_parser() -> argparse.ArgumentParser:
     fantasy_parser = sub.add_parser("fantasy", help="Generate fantasy projections")
     fantasy_parser.add_argument("player_ids", nargs="+", help="One or more player IDs")
 
+    events_parser = sub.add_parser("events", help="Lookup events by identifier")
+    events_parser.add_argument("event_ids", nargs="+", help="One or more event IDs")
+
     return parser
 
 
@@ -43,6 +46,11 @@ def main(argv: List[str] | None = None) -> int:
         print(json.dumps([projection.__dict__ for projection in projections], default=str, indent=2))
         return 0
 
+    if args.command == "events":
+        events = service.lookup_events(args.event_ids)
+        print(json.dumps([_serialize_event(event) for event in events], default=str, indent=2))
+        return 0
+
     parser.error("Unknown command")
     return 1
 
@@ -55,6 +63,17 @@ def _serialize_insight(insight):
         "odds": insight.odds.__dict__ if insight.odds else None,
         "spread_prediction": insight.spread_prediction.__dict__,
         "total_prediction": insight.total_prediction.__dict__,
+    }
+
+
+def _serialize_event(event):
+    return {
+        "event_id": event.event_id,
+        "date": event.event_date,
+        "home_team": event.home_team_name or event.home_team_id,
+        "away_team": event.away_team_name or event.away_team_id,
+        "venue": event.venue,
+        "status": event.status,
     }
 
 

--- a/stattrackerpro/models.py
+++ b/stattrackerpro/models.py
@@ -42,6 +42,8 @@ class Event:
     status: Optional[str] = None
     home_score: Optional[int] = None
     away_score: Optional[int] = None
+    home_team_name: Optional[str] = None
+    away_team_name: Optional[str] = None
 
     @property
     def is_final(self) -> bool:

--- a/stattrackerpro/providers/base.py
+++ b/stattrackerpro/providers/base.py
@@ -20,6 +20,10 @@ class SportsDataProvider(abc.ABC):
         """Return upcoming or recent events for a league."""
 
     @abc.abstractmethod
+    def lookup_events(self, event_ids: Iterable[str]) -> List[Event]:
+        """Return detailed information for specific events."""
+
+    @abc.abstractmethod
     def get_team(self, team_id: str) -> Optional[TeamStats]:
         """Return a single team by identifier when supported."""
 

--- a/stattrackerpro/services/analytics.py
+++ b/stattrackerpro/services/analytics.py
@@ -56,6 +56,9 @@ class AnalyticsService:
         stats: List[PlayerStats] = self.collector.player_stats(player_ids)
         return self.fantasy_projector.project(stats)
 
+    def lookup_events(self, event_ids: Iterable[str]) -> List[Event]:
+        return self.collector.lookup_events(event_ids)
+
     @staticmethod
     def combine_spread_predictions(predictions: Iterable[SpreadPrediction]) -> SpreadPrediction:
         return ensemble_spread(list(predictions))

--- a/stattrackerpro/services/stat_collector.py
+++ b/stattrackerpro/services/stat_collector.py
@@ -24,6 +24,9 @@ class StatCollector:
     def events(self, league_id: str, *, from_date: Optional[date] = None) -> List[Event]:
         return self.provider.get_events(league_id, from_date=from_date)
 
+    def lookup_events(self, event_ids: Iterable[str]) -> List[Event]:
+        return self.provider.lookup_events(event_ids)
+
     def player_stats(self, player_ids: Iterable[str]) -> List[PlayerStats]:
         return self.provider.get_player_stats(player_ids)
 

--- a/tests/test_analytics_service.py
+++ b/tests/test_analytics_service.py
@@ -33,6 +33,17 @@ class StubProvider(SportsDataProvider):
             )
         ]
 
+    def lookup_events(self, event_ids):
+        return [
+            Event(
+                event_id=event_ids[0],
+                league_id="999",
+                home_team_id="1",
+                away_team_id="2",
+                event_date=date.today(),
+            )
+        ]
+
     def get_player_stats(self, player_ids):
         return [
             PlayerStats(

--- a/tests/test_thesportsdb_provider.py
+++ b/tests/test_thesportsdb_provider.py
@@ -1,0 +1,108 @@
+import sys
+import types
+from datetime import date
+
+
+httpx_stub = types.ModuleType("httpx")
+
+
+class _DummyHTTPError(Exception):
+    pass
+
+
+class _DummyRequestError(Exception):
+    pass
+
+
+class _DummyClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def get(self, *args, **kwargs):  # pragma: no cover - defensive stub
+        raise NotImplementedError("HTTP client not available in tests")
+
+    def close(self) -> None:
+        pass
+
+
+httpx_stub.Client = _DummyClient
+httpx_stub.HTTPStatusError = _DummyHTTPError
+httpx_stub.RequestError = _DummyRequestError
+sys.modules.setdefault("httpx", httpx_stub)
+
+from stattrackerpro.models import Event
+from stattrackerpro.providers.thesportsdb import TheSportsDBProvider
+
+
+class DummyClient:
+    def __init__(self, *, league_payload=None, event_payloads=None):
+        self.league_payload = league_payload or {}
+        self.event_payloads = event_payloads or {}
+        self.requests = []
+
+    def get_json(self, url, *, params=None, **kwargs):  # pragma: no cover - exercised in tests
+        self.requests.append({"url": url, "params": params})
+        if url.endswith("eventsnextleague.php"):
+            return self.league_payload
+        if url.endswith("lookupevent.php"):
+            event_id = params.get("id") if params else None
+            return self.event_payloads.get(event_id, {"events": []})
+        raise AssertionError(f"Unexpected URL: {url}")
+
+
+def test_lookup_events_returns_named_events():
+    payloads = {
+        "2052711": {
+            "events": [
+                {
+                    "idEvent": "2052711",
+                    "idLeague": "1234",
+                    "idHomeTeam": "5678",
+                    "idAwayTeam": "91011",
+                    "dateEvent": "2024-01-10",
+                    "strVenue": "Awesome Arena",
+                    "strStatus": "Scheduled",
+                    "intHomeScore": None,
+                    "intAwayScore": None,
+                    "strHomeTeam": "Home Heroes",
+                    "strAwayTeam": "Road Warriors",
+                }
+            ]
+        }
+    }
+    provider = TheSportsDBProvider(client=DummyClient(event_payloads=payloads))
+
+    events = provider.lookup_events(["2052711"])
+
+    assert len(events) == 1
+    event = events[0]
+    assert isinstance(event, Event)
+    assert event.event_id == "2052711"
+    assert event.home_team_name == "Home Heroes"
+    assert event.away_team_name == "Road Warriors"
+    assert event.event_date == date(2024, 1, 10)
+
+
+def test_get_events_includes_team_names():
+    league_payload = {
+        "events": [
+            {
+                "idEvent": "8888",
+                "idLeague": "555",
+                "idHomeTeam": "100",
+                "idAwayTeam": "200",
+                "dateEvent": "2024-02-01",
+                "strHomeTeam": "Alpha",
+                "strAwayTeam": "Beta",
+            }
+        ]
+    }
+    provider = TheSportsDBProvider(client=DummyClient(league_payload=league_payload))
+
+    events = provider.get_events("555")
+
+    assert len(events) == 1
+    event = events[0]
+    assert event.home_team_name == "Alpha"
+    assert event.away_team_name == "Beta"
+    assert event.event_date == date(2024, 2, 1)


### PR DESCRIPTION
## Summary
- add support for looking up specific events by ID via TheSportsDB's free lookup endpoint
- expose the functionality through a new `stattrackerpro events` CLI command and updated analytics plumbing
- document the free lookup workflow and cover the provider with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5a02eefe8832c925c8f6dbefe7da4