### PR TITLE
Restrict setuptools package discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ gambler-gui = "saavygambler.gui.__main__:main"
 requires = ["setuptools>=65", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools.packages.find]
+include = ["saavygambler*"]
+
 [tool.pytest.ini_options]
 pythonpath = ["."]
 addopts = "-q"


### PR DESCRIPTION
## Summary
- configure setuptools to only discover the saavygambler package
- prevent the android directory from being treated as a top-level package during builds

## Testing
- python3 -m build *(fails: module build is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e6129612c4832cbbd07083431778cd