### PR TITLE
Handle invalid event dates from TheSportsDB

### DIFF
--- a/saavygambler/providers/thesportsdb.py
+++ b/saavygambler/providers/thesportsdb.py
@@ -159,11 +159,7 @@ class TheSportsDBProvider(SportsDataProvider):
             return None
 
     def _build_event(self, item: dict) -> Event:
-        event_date_str = item.get("dateEvent")
-        if event_date_str:
-            event_date = datetime.strptime(event_date_str, "%Y-%m-%d").date()
-        else:
-            event_date = date.today()
+        event_date = self._parse_event_date(item.get("dateEvent"))
         return Event(
             event_id=item.get("idEvent", ""),
             league_id=item.get("idLeague"),
@@ -177,6 +173,15 @@ class TheSportsDBProvider(SportsDataProvider):
             home_team_name=item.get("strHomeTeam"),
             away_team_name=item.get("strAwayTeam"),
         )
+
+    @staticmethod
+    def _parse_event_date(value: Optional[str]) -> date:
+        if not value:
+            return date.today()
+        try:
+            return datetime.strptime(value, "%Y-%m-%d").date()
+        except (TypeError, ValueError):
+            return date.today()
 
 
 __all__ = ["TheSportsDBProvider"]

--- a/tests/test_thesportsdb_provider.py
+++ b/tests/test_thesportsdb_provider.py
@@ -110,6 +110,29 @@ def test_get_events_includes_team_names():
     assert event.event_date == date(2024, 2, 1)
 
 
+def test_get_events_handles_invalid_dates_gracefully():
+    league_payload = {
+        "events": [
+            {
+                "idEvent": "9999",
+                "idLeague": "555",
+                "idHomeTeam": "100",
+                "idAwayTeam": "200",
+                "dateEvent": "not-a-date",
+                "strHomeTeam": "Alpha",
+                "strAwayTeam": "Beta",
+            }
+        ]
+    }
+    provider = TheSportsDBProvider(client=DummyClient(league_payload=league_payload))
+
+    events = provider.get_events("555")
+
+    assert len(events) == 1
+    event = events[0]
+    assert event.event_date == date.today()
+
+
 def test_provider_uses_free_lookup_key_when_api_key_missing():
     dummy_client = DummyClient(event_payloads={"42": {"events": []}})
     fake_settings = types.SimpleNamespace(sportsdb_api_key="   ")


### PR DESCRIPTION
## Summary
- guard TheSportsDB event parsing against invalid date strings by falling back to today
- add regression test covering malformed `dateEvent` payloads

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e64d5cdd0c832cbc6a139fe3ea0191